### PR TITLE
Added PersistentStats script allowing stats to be stored between Scenes

### DIFF
--- a/Assets/Prefabs/PersistentStats.prefab
+++ b/Assets/Prefabs/PersistentStats.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5719673250423961797
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5180548890346149076}
+  - component: {fileID: 6010546250221904256}
+  m_Layer: 0
+  m_Name: PersistentStats
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5180548890346149076
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5719673250423961797}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 3.2023792, y: 10.549843, z: -257.91455}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6010546250221904256
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5719673250423961797}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1844fa4aed0fa8ba48133620add43012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moneyCount: 0

--- a/Assets/Prefabs/PersistentStats.prefab.meta
+++ b/Assets/Prefabs/PersistentStats.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fc2b64a179dd3b3698d4f22b47610952
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -487,6 +487,75 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!1001 &880698814
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5180548890346149076, guid: fc2b64a179dd3b3698d4f22b47610952,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.2023792
+      objectReference: {fileID: 0}
+    - target: {fileID: 5180548890346149076, guid: fc2b64a179dd3b3698d4f22b47610952,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.549843
+      objectReference: {fileID: 0}
+    - target: {fileID: 5180548890346149076, guid: fc2b64a179dd3b3698d4f22b47610952,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -257.91455
+      objectReference: {fileID: 0}
+    - target: {fileID: 5180548890346149076, guid: fc2b64a179dd3b3698d4f22b47610952,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5180548890346149076, guid: fc2b64a179dd3b3698d4f22b47610952,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5180548890346149076, guid: fc2b64a179dd3b3698d4f22b47610952,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5180548890346149076, guid: fc2b64a179dd3b3698d4f22b47610952,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5180548890346149076, guid: fc2b64a179dd3b3698d4f22b47610952,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5180548890346149076, guid: fc2b64a179dd3b3698d4f22b47610952,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5180548890346149076, guid: fc2b64a179dd3b3698d4f22b47610952,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5180548890346149076, guid: fc2b64a179dd3b3698d4f22b47610952,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5719673250423961797, guid: fc2b64a179dd3b3698d4f22b47610952,
+        type: 3}
+      propertyPath: m_Name
+      value: PersistentStats
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fc2b64a179dd3b3698d4f22b47610952, type: 3}
 --- !u!1 &994204172
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameState.cs
+++ b/Assets/Scripts/GameState.cs
@@ -6,6 +6,8 @@ public class GameState : MonoBehaviour
 {
     private EnemySpawner enemySpawner;
     private SceneLoader sceneLoader;
+
+    private PersistentStats persistentStats;
     NodeInformation[,] nodeTierMatrix;
     GameObject levelGrid;
     NodeInformation currentSelectedNode;
@@ -31,6 +33,7 @@ public class GameState : MonoBehaviour
             {
                 enemySpawner.SetWaveComplete(false);
                 currentSelectedNode.SetIsComplete(true);
+                persistentStats.updateStats();
                 sceneLoader.ChangeToLevelSelect();
 
             }
@@ -64,6 +67,7 @@ public class GameState : MonoBehaviour
         {
             enemySpawner = FindObjectOfType<EnemySpawner>().GetComponent<EnemySpawner>();
             sceneLoader = FindObjectOfType<SceneLoader>().GetComponent<SceneLoader>();
+            persistentStats = FindObjectOfType<PersistentStats>().GetComponent<PersistentStats>();
 
         }
     }

--- a/Assets/Scripts/PersistentStats.cs
+++ b/Assets/Scripts/PersistentStats.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PersistentStats : MonoBehaviour
+{
+    // Start is called before the first frame update
+    [SerializeField] public int moneyCount = 0;
+    private PlayerStats playerStats;
+
+    public void updateStats(){
+        playerStats = FindObjectOfType<PlayerStats>().GetComponent<PlayerStats>();
+        this.moneyCount = playerStats.GetMoneyCount();
+    }
+        private void Awake()
+    {
+        int persistentStatsCount = FindObjectsOfType<PersistentStats>().Length;
+        if (persistentStatsCount > 1)
+        {
+            Destroy(gameObject);
+        }
+        else
+        {
+            DontDestroyOnLoad(gameObject);
+        }
+    }
+}

--- a/Assets/Scripts/PersistentStats.cs.meta
+++ b/Assets/Scripts/PersistentStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1844fa4aed0fa8ba48133620add43012
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/PlayerStats.cs
+++ b/Assets/Scripts/PlayerStats.cs
@@ -17,8 +17,13 @@ public class PlayerStats : MonoBehaviour
     private int numberOfEquippedWeapons = 0;
     private int weaponInventorySize;
 
+    private PersistentStats persistentStats;
+
     private void Start()
     {
+
+        persistentStats = FindObjectOfType<PersistentStats>().GetComponent<PersistentStats>();
+
         health = maxHealth;
         if(healthBar != null)
         {
@@ -36,7 +41,7 @@ public class PlayerStats : MonoBehaviour
         }
 
         armor = GetArmor();
-        moneyCount = GetMoneyCount();
+        moneyCount = persistentStats.moneyCount;
     }
 
     public int GetMoneyCount()


### PR DESCRIPTION
Added PersistentStats script which allows stats like moneyCount to be stored between Scenes.
Edited GameState and PlayerStats to accommodate this.