### PR TITLE
Added Weapon and Item Inventories to PersistentStats

### DIFF
--- a/Assets/Prefabs/PersistentStats.prefab
+++ b/Assets/Prefabs/PersistentStats.prefab
@@ -44,3 +44,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   moneyCount: 0
+  weaponInventory:
+  - {fileID: 11400000, guid: 0a497787e9c14ed44a48d634bfe02bfe, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}
+  itemInventory:
+  - {fileID: 11400000, guid: cb022c2cc1427448f8696f1080d20bec, type: 2}
+  - {fileID: 0}
+  - {fileID: 0}

--- a/Assets/Scripts/PersistentStats.cs
+++ b/Assets/Scripts/PersistentStats.cs
@@ -6,11 +6,19 @@ public class PersistentStats : MonoBehaviour
 {
     // Start is called before the first frame update
     [SerializeField] public int moneyCount = 0;
+
+    [SerializeField] private Weapon[] weaponInventory = new Weapon[3];
+    [SerializeField] private UsableItem[] itemInventory = new UsableItem[3];
+
     private PlayerStats playerStats;
 
     public void updateStats(){
         playerStats = FindObjectOfType<PlayerStats>().GetComponent<PlayerStats>();
         this.moneyCount = playerStats.GetMoneyCount();
+
+        this.weaponInventory = playerStats.GetWeaponInventory();
+        this.itemInventory = playerStats.GetItemInventory();
+
     }
         private void Awake()
     {
@@ -23,5 +31,17 @@ public class PersistentStats : MonoBehaviour
         {
             DontDestroyOnLoad(gameObject);
         }
+    }
+
+    public Weapon[] GetWeaponInventory(){
+        Weapon[] returnWeaponInventory = new Weapon[weaponInventory.Length];
+        weaponInventory.CopyTo(returnWeaponInventory, 0);
+        return returnWeaponInventory;
+    }
+
+    public UsableItem[] GetItemInventory(){
+        UsableItem[] returnItemInventory = new UsableItem[itemInventory.Length];
+        itemInventory.CopyTo(returnItemInventory, 0);
+        return returnItemInventory;
     }
 }

--- a/Assets/Scripts/PlayerStats.cs
+++ b/Assets/Scripts/PlayerStats.cs
@@ -8,9 +8,9 @@ public class PlayerStats : MonoBehaviour
     [SerializeField] private float armor = 0.0f;
     [SerializeField] int maxHealth = 100;
     [SerializeField] HealthBar healthBar = default;
-    [SerializeField] Weapon[] weaponInventory = new Weapon[3];
+    [SerializeField] public Weapon[] weaponInventory = new Weapon[3];
     [SerializeField] public Weapon currentWeapon;
-    [SerializeField] UsableItem[] itemInventory = new UsableItem[3];
+    [SerializeField] public UsableItem[] itemInventory = new UsableItem[3];
 
     private int health;
     private int currentWeaponSlot;
@@ -23,6 +23,10 @@ public class PlayerStats : MonoBehaviour
     {
 
         persistentStats = FindObjectOfType<PersistentStats>().GetComponent<PersistentStats>();
+        this.moneyCount = persistentStats.moneyCount;
+        this.weaponInventory = persistentStats.GetWeaponInventory();
+        this.itemInventory = persistentStats.GetItemInventory();
+
 
         health = maxHealth;
         if(healthBar != null)
@@ -41,7 +45,6 @@ public class PlayerStats : MonoBehaviour
         }
 
         armor = GetArmor();
-        moneyCount = persistentStats.moneyCount;
     }
 
     public int GetMoneyCount()
@@ -120,6 +123,18 @@ public class PlayerStats : MonoBehaviour
         {
             weaponInventory[weaponInventory.Length] = newWeapon;
         }
+    }
+
+    public Weapon[] GetWeaponInventory(){
+        Weapon[] returnWeaponInventory = new Weapon[weaponInventory.Length];
+        weaponInventory.CopyTo(returnWeaponInventory, 0);
+        return returnWeaponInventory;
+    }
+
+    public UsableItem[] GetItemInventory(){
+        UsableItem[] returnItemInventory = new UsableItem[itemInventory.Length];
+        itemInventory.CopyTo(returnItemInventory, 0);
+        return returnItemInventory;
     }
 
     public void TakeDamage(int attackDamage)


### PR DESCRIPTION
Added Weapon and Item Inventories to Persistent Stats. Also added Getter functions to return a copy of the inventories (not references to the arrays). If you wish to set the default inventories for the start of the game, you will now need to edit the PersistentStats Prefab, not the Player Prefab.